### PR TITLE
dgram: remove useless parameter type.

### DIFF
--- a/deps/dgram.lua
+++ b/deps/dgram.lua
@@ -50,7 +50,7 @@ local function stop_listening(self)
 end
 
 local Socket = Emitter:extend()
-function Socket:initialize(type, callback)
+function Socket:initialize(callback)
   self._handle = uv.new_udp()
   if callback then
     self:on('message', callback)


### PR DESCRIPTION
This is useless so it is confusing to let it here.